### PR TITLE
fix: guard ConfigureDbContext() Migrate() with IHistoryRepository (Galera-safe)

### DIFF
--- a/eFormAPI/Plugins/OuterInnerResource.Pn/OuterInnerResource.Pn/EformOuterInnerResourcePlugin.cs
+++ b/eFormAPI/Plugins/OuterInnerResource.Pn/OuterInnerResource.Pn/EformOuterInnerResourcePlugin.cs
@@ -36,6 +36,8 @@ namespace OuterInnerResource.Pn
     using System.Reflection;
     using Microsoft.AspNetCore.Builder;
     using Microsoft.EntityFrameworkCore;
+    using Microsoft.EntityFrameworkCore.Infrastructure;
+    using Microsoft.EntityFrameworkCore.Migrations;
     using Microsoft.Extensions.Configuration;
     using Microsoft.Extensions.DependencyInjection;
     using Microting.eFormApi.BasePn;
@@ -162,7 +164,11 @@ namespace OuterInnerResource.Pn
 
             using (var context = contextFactory.CreateDbContext(new[] { connectionString }))
             {
-                context.Database.Migrate();
+                var historyRepo = context.GetService<IHistoryRepository>();
+                if (!historyRepo.Exists() || context.Database.GetPendingMigrations().Any())
+                {
+                    context.Database.Migrate();
+                }
                 try
                 {
                     _outerResourceName = context.PluginConfigurationValues.FirstOrDefault(x => x.Name == "OuterInnerResourceSettings:OuterResourceName")?.Value;


### PR DESCRIPTION
## Summary

- Wrap `Database.Migrate()` in `ConfigureDbContext()` with an `IHistoryRepository.Exists()` guard to eliminate unnecessary DDL on every API pod restart

## Why

On a MariaDB 11.4 Galera cluster with ~250 tenants, `Database.Migrate()` issues DDL (`CREATE TABLE IF NOT EXISTS __EFMigrationsHistory`, `GET_LOCK`) on every app restart even when the schema is already current. With multiple pods per tenant this causes cluster-wide desync/resync on every rolling update.

The guard pattern:
- `IHistoryRepository.Exists()` — safe `information_schema` read, returns false if history table is absent
- `GetPendingMigrations().Any()` — only called when the table exists
- `Database.Migrate()` — called **only** when needed: fresh install, or pending migrations

In production (schema current): no DDL, no `GET_LOCK`. On fresh plugin activation: falls through and creates the schema.

## Test Plan
- [ ] Plugin activates from UI correctly (schema created on first activation)
- [ ] Subsequent pod restarts do not trigger DDL when schema is current

🤖 Generated with [Claude Code](https://claude.com/claude-code)